### PR TITLE
feat: added styling as second param to addCanvas function

### DIFF
--- a/src/components/SketchCanvas/SketchCanvas.tsx
+++ b/src/components/SketchCanvas/SketchCanvas.tsx
@@ -14,7 +14,12 @@ import React, {
 import { drawingState, derivedPaths } from '../../store';
 import { useSnapshot } from 'valtio';
 import { createHistoryStack, createSvgFromPaths } from '../../utils';
-import type { SketchCanvasRef, SketchCanvasProps, Point } from './types';
+import type {
+  SketchCanvasRef,
+  SketchCanvasProps,
+  Point,
+  StyleOptions,
+} from './types';
 import { ImageFormat } from './types';
 import { STROKE_COLOR, STROKE_STYLE, STROKE_WIDTH } from './constants';
 
@@ -88,13 +93,13 @@ export const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
       toPoints: () => {
         return drawingState.completedPoints.map((p) => p.points);
       },
-      addPoints: (points: Point[][]) => {
+      addPoints: (points: Point[][], style?: StyleOptions) => {
         const formatted = points.map((data) => ({
           id: Date.now(),
           points: data,
-          color: STROKE_COLOR,
-          width: STROKE_WIDTH,
-          style: STROKE_STYLE,
+          color: style?.strokeColor ?? STROKE_COLOR,
+          width: style?.strokeWidth ?? STROKE_WIDTH,
+          style: style?.strokeStyle ?? STROKE_STYLE,
         }));
         drawingState.completedPoints = formatted;
       },

--- a/src/components/SketchCanvas/types.ts
+++ b/src/components/SketchCanvas/types.ts
@@ -17,7 +17,7 @@ export interface SketchCanvasRef {
   toImage: () => SkImage | undefined;
   toSvg: (width: number, height: number, backgroundColor?: string) => string;
   toPoints: () => Point[][];
-  addPoints: (points: Point[][]) => void;
+  addPoints: (points: Point[][], style?: StyleOptions) => void;
 }
 
 export interface SketchCanvasProps {
@@ -27,6 +27,12 @@ export interface SketchCanvasProps {
   containerStyle?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
   topChildren?: React.ReactNode;
+}
+
+export interface StyleOptions {
+  strokeColor?: Color;
+  strokeStyle?: 'stroke' | 'fill';
+  strokeWidth?: number;
 }
 
 export type Point = [number, number];


### PR DESCRIPTION
this allows to add custom styling when adding the points back

```
const drawStyleOptions: StyleOptions = {
  strokeColor: "#FF3838",
  strokeStyle: "fill",
  strokeWidth: 4,
};

canvasRef.current?.addPoints(drawpoints, drawStyleOptions)
```