### PR TITLE
fix: delete comma in svg string

### DIFF
--- a/src/utils/create-svg-from-paths.ts
+++ b/src/utils/create-svg-from-paths.ts
@@ -22,7 +22,7 @@ export default function createSvgFromPaths(
     options.backgroundColor || 'white'
   }"/>
   <g>
-    ${paths.map((path) => `<path d="${path.path}" stroke="${path.color}" />`)}
+    ${paths.map((path) => `<path d="${path.path}" stroke="${path.color}" />`).join('')}
     </g>
     </svg>`;
 }


### PR DESCRIPTION
when convert many lines with toSvg, there is a comma between <path> in svg string