### PR TITLE
feat: Add handler for start and end of the touch

### DIFF
--- a/src/components/SketchCanvas/SketchCanvas.tsx
+++ b/src/components/SketchCanvas/SketchCanvas.tsx
@@ -33,6 +33,8 @@ export const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
       children,
       topChildren,
       bottomChildren,
+      onTouchStart = () => {},
+      onTouchEnd = () => {},
     },
     ref
   ) => {
@@ -111,6 +113,7 @@ export const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
         onStart: (touchInfo: TouchInfo) => {
           drawingState.isDrawing = true;
           drawingState.currentPoints.points = [[touchInfo.x, touchInfo.y]];
+          onTouchStart();
         },
         onActive: (touchInfo: TouchInfo) => {
           if (!drawingState.isDrawing) {
@@ -145,6 +148,7 @@ export const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
             currentPoints: drawingState.currentPoints,
             completedPoints: drawingState.completedPoints,
           });
+          onTouchEnd();
         },
       },
       [strokeColor, strokeStyle]

--- a/src/components/SketchCanvas/types.ts
+++ b/src/components/SketchCanvas/types.ts
@@ -28,6 +28,8 @@ export interface SketchCanvasProps {
   children?: React.ReactNode;
   topChildren?: React.ReactNode;
   bottomChildren?: React.ReactNode;
+  onTouchStart?: () => void;
+  onTouchEnd?: () => void;
 }
 
 export interface StyleOptions {


### PR DESCRIPTION
Added callback for touchHandler:

 - `onTouchStart` - called on start of the touch
 - `onTouchEnd` - called on the end of the touch

I found this feature really helpful, since we need to check if user already started/finished drawing. 
I didn't find any other solution, how can be sure and make some logic, that user draw something, eg. once they finish drawing, we can enable button for submit, etc. 

This is my first contribution, I read guidelines, so I hope I did it in the good way. 
If it doesn't meet your requirements, please let me know and I will fix it. 

Thanks

